### PR TITLE
remove all formatting for 'properties' on ScalaCheck properties. fixe…

### DIFF
--- a/scalacheck/src/main/scala/org/specs2/scalacheck/ScalaCheckPropertyDsl.scala
+++ b/scalacheck/src/main/scala/org/specs2/scalacheck/ScalaCheckPropertyDsl.scala
@@ -12,7 +12,7 @@ trait ScalaCheckPropertyDsl extends FragmentsFactory with AsResultProp {
 
   /** display properties as examples */
   def properties(ps: Properties): Fragments =
-    Fragments(fragmentFactory.tab) append Fragments.foreach(ps.properties) { case (name, prop) =>
+    Fragments.foreach(ps.properties) { case (name, prop) =>
       Fragments(fragmentFactory.break, fragmentFactory.example(name, prop))
     }
 


### PR DESCRIPTION
…s #545